### PR TITLE
Add a __repr__ method to the BitcodinObject base class

### DIFF
--- a/bitcodin/resource.py
+++ b/bitcodin/resource.py
@@ -58,6 +58,9 @@ class BitcodinObject(dict):
         self.to_object()
         return json_string
 
+    def __repr__(self):
+        return repr(self.__dict__)
+
     def __getattr__(self, name):
         if name in self:
             return self[name]


### PR DESCRIPTION
__repr__ is called by str/repr/print etc. to get a string representation of the object.
This is very useful for quick debugging.