### PR TITLE
Revert using less secure API endpoint

### DIFF
--- a/bitcodin/__init__.py
+++ b/bitcodin/__init__.py
@@ -3,7 +3,7 @@ __author__ = 'dmoser'
 # Configuration variables
 
 api_key = None
-api_base = 'http://portal.bitcodin.com/api'
+api_base = 'https://portal.bitcodin.com/api'
 api_version = None
 
 from bitcodin.resource import *


### PR DESCRIPTION
In #2 it was proposed to use http instead of https.
However, this change required us to manually overwrite the `api_base` to use the https variant.
Using http allows the API key, and other secrets (HTTP password, SFTP password, S3 key, Azure key) to be intercepted.

As noted by @jaap3 older Python versions can work around this problem by simply updating their Python version, updating urllib3, or knowingly setting the `api_base` to the less secure version by hand.

Unless @msmole has a good reason the default should be http?