### PR TITLE
Added methods for boolean and length representations to BitcodinObject

### DIFF
--- a/bitcodin/resource.py
+++ b/bitcodin/resource.py
@@ -73,6 +73,12 @@ class BitcodinObject(dict):
         else:
             raise AttributeError('No such attribute: ' + name)
 
+    def __bool__(self):
+        return bool(self.__dict__)
+
+    def __len__(self):
+        return len(self.__dict__)
+
 
 class Input(BitcodinObject):
 

--- a/bitcodin/test/core/__init__.py
+++ b/bitcodin/test/core/__init__.py
@@ -8,7 +8,7 @@ from .testcase_create_headers import CreateHttpHeadersTestCase
 from .testcase_convert import ConvertTestCase
 from .testcase_convert_dict import ConvertDictTestCase
 from .testcase_get_api_base import GetApiBaseTestCase
-
+from .testcase_bitcodinobject import BitcodinObjectBooleanTestCase
 
 def get_test_suite():
     test_suite = TestSuite()
@@ -18,4 +18,6 @@ def get_test_suite():
     test_suite.addTest(CreateHttpHeadersTestCase())
     test_suite.addTest(ApiKeyAuthorizedTestCase())
     test_suite.addTest(ApiKeyUnauthorizedTestCase())
+    test_suite.addTest(BitcodinObjectBooleanTestCase())
+    test_suite.addTest(BitcodinObjectLengthTestCase())
     return test_suite

--- a/bitcodin/test/core/__init__.py
+++ b/bitcodin/test/core/__init__.py
@@ -9,6 +9,8 @@ from .testcase_convert import ConvertTestCase
 from .testcase_convert_dict import ConvertDictTestCase
 from .testcase_get_api_base import GetApiBaseTestCase
 from .testcase_bitcodinobject import BitcodinObjectBooleanTestCase
+from .testcase_bitcodinobject import BitcodinObjectLengthTestCase
+
 
 def get_test_suite():
     test_suite = TestSuite()

--- a/bitcodin/test/core/testcase_bitcodinobject.py
+++ b/bitcodin/test/core/testcase_bitcodinobject.py
@@ -1,0 +1,34 @@
+__author__ = 'Jan Češpivo <jan.cespivo@coex.cz>'
+
+import unittest
+
+from bitcodin.resource import BitcodinObject
+from bitcodin.test.bitcodin_test_case import BitcodinTestCase
+
+
+class BitcodinObjectBooleanTestCase(BitcodinTestCase):
+    def test_not_empty(self):
+        not_empty_bitcodin_object = BitcodinObject({'some_key': 'some_value'})
+        boolean_representation = bool(not_empty_bitcodin_object)
+        self.assertEqual(boolean_representation, True)
+
+    def test_empty(self):
+        empty_bitcodin_object = BitcodinObject({})
+        boolean_representation = bool(empty_bitcodin_object)
+        self.assertEqual(boolean_representation, False)
+
+
+class BitcodinObjectLengthTestCase(BitcodinTestCase):
+    def test_not_empty(self):
+        not_empty_bitcodin_object = BitcodinObject({'some_key': 'some_value'})
+        length = len(not_empty_bitcodin_object)
+        self.assertEqual(length, 1)
+
+    def test_empty(self):
+        empty_bitcodin_object = BitcodinObject({})
+        length = len(empty_bitcodin_object)
+        self.assertEqual(length, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi,
there are no `__bool__` and `__len__` methods defined in BitcodinObject so it doesn't behave like a dict.
